### PR TITLE
Large refactor with an emphasis on decoupling classes.

### DIFF
--- a/.idea/dictionaries/germainjones.xml
+++ b/.idea/dictionaries/germainjones.xml
@@ -2,7 +2,10 @@
   <dictionary name="germainjones">
     <words>
       <w>djinn</w>
+      <w>djinns</w>
+      <w>elementals</w>
       <w>mana</w>
+      <w>yeetmeister</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/game_code/actions/__init__.py
+++ b/game_code/actions/__init__.py
@@ -1,117 +1,147 @@
-from game_code.response import AttackResponse, NullResponse
+"""
+Library contains Action classes used for creatures to affect the world.
+"""
+from game_code.creatures import Creature
+from game_code.response import NullResponse, AttackResponse
 
 
 class Action:
     """
-    Sent when a creature attempts to interact with the world.
+    Base Action class. When a Creature instance wants to affect the world in some way they will use an action instance.
+    It calculates the outcome of their action and carries out changes caused by the action.
     """
 
-    def __init__(self, executor: "Creature", target: "Creature", tool_used):
+    def __init__(
+            self, executor: Creature = None, target: Creature = None, tool_used=None, damage: int = None,
+            hit_index: int = None, healing_quantity: int = None):
         self._executor = executor
         self._target = target
         self._tool_used = tool_used
+        self._damage = damage
+        self._hit_index = hit_index
+        self._healing_quantity = healing_quantity
 
-    def __call__(self) -> NullResponse:
+    def __call__(self):
         return self.main()
 
-    def main(self) -> NullResponse:
+    def main(self) -> None:
         """
-        Calculate and perform the action.
-        :return: A NullResponse object that has no information.
+        Logic to calculate the outcome of an action and performs it.
+        Example: Figure out if an attack landed and deduct the relevant health from the target of the attack.
         """
-        return NullResponse()
+        pass
 
-    def executor(self) -> "Creature":
+    def executor(self) -> Creature:
         """
         :return: Creature performing the action.
         """
         return self._executor
 
-    def target(self) -> "Creature":
+    def target(self) -> Creature:
         """
-        :return: Object being acted upon.
+        :return: Creature targeted by the action.
         """
         return self._target
 
     def tool_used(self):
+        """
+        :return: Weapon, Skill, Item or other that was used as a medium for the action.
+        """
         return self._tool_used
+
+    def damage(self) -> int:
+        """
+        :return: Potential damage dealt to deal to target.
+        """
+        return self._damage
+
+    def hit_index(self) -> int:
+        """
+        :return: Number between 1 and 20 inclusive used to calculate if an attack lands.
+        """
+        return self._hit_index
+
+    def healing_quantity(self) -> int:
+        """
+        :return: Potential quantity to heal target by.
+        """
+        return self._healing_quantity
 
 
 class NullAction(Action):
     """
-    Sent as placeholder action comparable to NoneType for actions.
+    Action used when no action is taken.
     """
+
+    def __init__(self):
+        super().__init__()
+
+    def main(self) -> NullResponse:
+        """
+        :return: NullResponse instance with no data.
+        """
+        return NullResponse()
 
 
 class AttackAction(Action):
     """
-    Sent when a creature attempts an attack against another object.
+    Action used when a Creature attacks a Creature.
     """
 
-    def __init__(self, damage, hit_index, **kwargs):
-        super().__init__(**kwargs)
-        self._damage = damage
-        self._hit_index = hit_index
+    def __init__(self, executor: Creature, target: Creature, hit_index: int, damage: int, tool_used):
+        super().__init__(executor=executor, target=target, hit_index=hit_index, damage=damage, tool_used=tool_used)
 
     def main(self) -> AttackResponse:
+        # TODO: Implement reduction of target health if attack lands.
         """
         Calculate the whether the attack hit and how much damage was dealt.
         :return: AttackResponse object with information what happen in text format.
         """
         attack_points = self._hit_index + self._executor.stats().physicality()
         target_dexterity = self._target.stats().dexterity()
-        defense_points = 2 * target_dexterity if self._target.status().is_blocking() else target_dexterity
+        defense_points = (self._target.status().is_blocking() + 1) * target_dexterity
 
         if self._hit_index == 20:
-            damage = self._damage
             outcome = "critical_hit"
-        elif self._hit_index == 1:
-            damage = 0
-            outcome = "critical_miss"
-        elif defense_points < attack_points:
             damage = self._damage
-            outcome = "hit"
-        else:
+        elif self._hit_index == 1:
+            outcome = "critical_miss"
             damage = 0
+        elif defense_points < attack_points:
+            outcome = "hit"
+            damage = self._damage
+        else:
             outcome = "miss"
+            damage = 0
 
-        return AttackResponse(executor_name=self._executor.full_name(), target_name=self._target.full_name(),
-                              tool_name=self._tool_used.name(), damage=damage, outcome=outcome)
-
-    def damage(self) -> int:
-        """
-        :return: Damage dealt to target should the attack land.
-        """
-        return self._damage
-
-    def hit_index(self) -> int:
-        """
-        :return: A number between 1 and 20 inclusive that is used to calculate if an attack lands.
-        """
-        return self._hit_index
+        return AttackResponse(
+            executor_name=self._executor.full_name(), target_name=self._target.full_name(),
+            tool_name=self._tool_used.name(), damage=damage, outcome=outcome
+        )
 
 
 # TODO: Implement healing response for healing actions.
 class HealingAction(Action):
     """
-    Sent when a creature attempts to heal another object.
+    Action used when a Creature attempts to heal a creature.
     """
 
-    def __init__(self, healing_quantity, **kwargs):
-        super().__init__(**kwargs)
-        self._healing_quantity = healing_quantity
+    def __init__(self, executor: Creature, target: Creature, healing_quantity: int, tool_used):
+        super().__init__(executor=executor, target=target, healing_quantity=healing_quantity, tool_used=tool_used)
 
-    def healing_quantity(self) -> int:
-        """
-        :return: How much to heal to heal the target by.
-        """
-        return self._healing_quantity
+    def main(self) -> None:
+        # TODO: Implement method
+        pass
 
 
 class BlockAction(Action):
     """
-    Sent when a creature decides to initiate a defensive stance.
+    Action used when a Creature attempts to block on their turn.
     """
 
-    def __init__(self, tool_used=None, **kwargs):
-        super().__init__(tool_used=tool_used, **kwargs)
+    def __init__(self, executor: Creature):
+        super().__init__(executor=executor, target=executor)
+
+    def main(self) -> None:
+        # TODO: Implement method
+        pass

--- a/game_code/actions/tests.py
+++ b/game_code/actions/tests.py
@@ -1,42 +1,101 @@
+"""
+All tests for the actions library.
+"""
+
 import unittest
+from copy import deepcopy
 
-from game_code.actions import AttackAction, HealingAction
-from game_code.creatures import Creature
-
-
-class TestAttackActionMethods(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.executor = Creature()
-        cls.target = Creature()
-        cls.attack = AttackAction(executor=cls.executor, target=cls.target, damage=5, hit_index=6,
-                                  tool_used="Placeholder")
-
-    def test_executor(self):
-        self.assertEqual(self.executor, self.attack.executor())
-
-    def test_target(self):
-        self.assertEqual(self.target, self.attack.target())
-
-    def test_damage(self):
-        self.assertEqual(5, self.attack.damage())
-
-    def test_hit_index(self):
-        self.assertEqual(6, self.attack.hit_index())
+from game_code.actions import AttackAction
+from game_code.creatures import Goblin
+from game_code.stats import Stats
+from game_code.status import Status, Block
+from game_code.weapons import Sword
 
 
-class TestHealingActionMethods(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.executor = Creature()
-        cls.target = Creature()
-        cls.heal = HealingAction(executor=cls.executor, target=cls.target, healing_quantity=11, tool_used="Placeholder")
+class TestAttackAction(unittest.TestCase):
+    def setUp(self) -> None:
+        """
+        Creates two goblin instances for each test. They both have all stats at 0 and a sword.
+        """
+        sword = Sword(base_value=0, dice_quantity=0, dice_max=0, weight=0, value=0)
+        kwargs = {"second_name": "Goblin", "stats": Stats(), "status": Status(), "weapon": sword}
+        self.attacker = Goblin(first_name="Attacker", **deepcopy(kwargs))
+        self.defender = Goblin(first_name="Defender", **deepcopy(kwargs))
 
-    def test_executor(self):
-        self.assertEqual(self.executor, self.heal.executor())
+    def test_critical_hit(self):
+        attack = AttackAction(
+            executor=self.attacker, target=self.defender, tool_used=self.attacker.weapon(), hit_index=20, damage=0
+        )
+        response = attack()
+        response_result = response()
+        self.assertTrue("Critical Hit!" in response_result[1])
 
-    def test_target(self):
-        self.assertEqual(self.target, self.heal.target())
+    def test_critical_hit_with_defender_blocking(self):
+        self.defender.status().add_effect(Block(turns=1))
 
-    def test_health_quantity(self):
-        self.assertEqual(11, self.heal.healing_quantity())
+        attack = AttackAction(
+            executor=self.attacker, target=self.defender, tool_used=self.attacker.weapon(), hit_index=20, damage=0
+        )
+        response = attack()
+        response_result = response()
+        self.assertTrue("Critical Hit!" in response_result[1])
+
+    def test_hit(self):
+        self.defender.stats()._dexterity = 10
+
+        attack = AttackAction(
+            executor=self.attacker, target=self.defender, tool_used=self.attacker.weapon(), hit_index=11, damage=0
+        )
+        response = attack()
+        response_result = response()
+        self.assertTrue("attack lands" in response_result[1])
+
+    def test_hit_with_defender_blocking(self):
+        self.defender.status().add_effect(Block(turns=1))
+        self.defender.stats()._dexterity = 5
+
+        attack = AttackAction(
+            executor=self.attacker, target=self.defender, tool_used=self.attacker.weapon(), hit_index=11, damage=0
+        )
+        response = attack()
+        response_result = response()
+        self.assertTrue("attack lands" in response_result[1])
+
+    def test_miss(self):
+        self.defender.stats()._dexterity = 10
+
+        attack = AttackAction(
+            executor=self.attacker, target=self.defender, tool_used=self.attacker.weapon(), hit_index=10, damage=0
+        )
+        response = attack()
+        response_result = response()
+        self.assertTrue("attack misses" in response_result[1])
+
+    def test_miss_with_defender_blocking(self):
+        self.defender.status().add_effect(Block(turns=1))
+        self.defender.stats()._dexterity = 5
+
+        attack = AttackAction(
+            executor=self.attacker, target=self.defender, tool_used=self.attacker.weapon(), hit_index=10, damage=0
+        )
+        response = attack()
+        response_result = response()
+        self.assertTrue("attack misses" in response_result[1])
+
+    def test_critical_miss(self):
+        attack = AttackAction(
+            executor=self.attacker, target=self.defender, tool_used=self.attacker.weapon(), hit_index=1, damage=0
+        )
+        response = attack()
+        response_result = response()
+        self.assertTrue("Critical miss" in response_result[1])
+
+    def test_critical_miss_with_defender_blocking(self):
+        self.defender.status().add_effect(Block(turns=1))
+
+        attack = AttackAction(
+            executor=self.attacker, target=self.defender, tool_used=self.attacker.weapon(), hit_index=1, damage=0
+        )
+        response = attack()
+        response_result = response()
+        self.assertTrue("Critical miss" in response_result[1])

--- a/game_code/creatures/__init__.py
+++ b/game_code/creatures/__init__.py
@@ -1,36 +1,22 @@
+"""
+The living entities of the game.
+"""
 from game_code.stats import Stats
-from game_code.status import Status
 
 
 class Creature:
     """
     Living entity that all other living creatures are based on.
     """
+    _race = None
 
-    def __init__(self,
-                 first_name: str = "Unnamed",
-                 second_name: str = "",
-                 race: str = "Unknown",
-                 magic_base: int = 0,
-                 constitution: int = 0,
-                 physicality: int = 0,
-                 dexterity: int = 0,
-                 social: int = 0,
-                 experience: int = 0,
-                 weapon=None,
-                 magic_enabled: bool = True,
-                 gold_worth: int = 0,
-                 experience_worth: int = 0):
-        self._inventory = []
+    def __init__(self, first_name: str, second_name: str, stats, status, weapon):
         self._first_name = first_name
         self._second_name = second_name
-        self._race = race
-        self._stats = Stats(constitution=constitution, physicality=physicality, dexterity=dexterity, social=social,
-                            experience=experience, magic_enabled=magic_enabled, magic_base=magic_base)
+        self._stats = stats
+        self._status = status
         self._weapon = weapon
-        self._gold_worth = gold_worth
-        self._experience_worth = experience_worth
-        self._status = Status()
+        self._inventory = []
 
     def full_name(self) -> str:
         """
@@ -68,33 +54,20 @@ class Creature:
         """
         return self._stats
 
-    def status(self) -> Status:
+    def status(self) -> "Status":
         """
         :return: Status object of the creature.
         """
         return self._status
 
-    def weapon(self) -> "Weapon":
+    def weapon(self):
         """
         :return: Currently equipped weapon.
         """
         return self._weapon
 
-    def gold_worth(self) -> int:
-        """
-        :return: Gold reward for killing a creature (is distinct from the gold that a creature has in their inventory).
-        """
-        return self._gold_worth
-
-    def experience_worth(self) -> int:
-        """
-        :return: Experience reward for killing a creature (is distinct from the experience that a creature has
-        accumulated).
-        """
-        return self._experience_worth
-
-    # TODO: Refactor the equip weapon methods once an inventory object has been created.
-    def equip_weapon(self, weapon: "Weapon") -> None:
+    # TODO: Refactor the equip weapon  once an inventory object has been created.
+    def equip_weapon(self, weapon) -> None:
         """
         Place the current weapon in the inventory and replace it with the weapon parameter.
         :param weapon: Weapon to equip.
@@ -110,49 +83,69 @@ class Creature:
             self._inventory.append(self._weapon)
         self._weapon = None
 
-    def _grab_weapon(self, weapon: "Weapon") -> None:
+    def _grab_weapon(self, weapon) -> None:
         """
         Set new weapon field.
         :param weapon: New current weapon.
         """
         self._weapon = weapon
 
-    # TODO: Figure out the logistics of how an attack will work and create Attack objects.
-    def basic_attack(self):
-        pass
-
 
 class Goblin(Creature):
+    """
+    Goblin creature.
+    """
+    _race = "Goblin"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._race = "Goblin"
 
 
 class Orc(Creature):
+    """
+    Orc creature.
+    """
+    _race = "Orc"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._race = "Orc"
 
 
 class EarthElemental(Creature):
+    """
+    Earth Elemental creature. They have a racial skill - Rock Fist.
+    """
+    _race = "Earth Elemental"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._race = "Earth Elemental"
 
 
 class Djinn(Creature):
+    """
+    Djinn creature. They have a racial skill - Harsh Language.
+    """
+    _race = "Djinn"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._race = "Djinn"
 
 
 class Dragon(Creature):
+    """
+    Dragon creature. They have a racial skill - Fire Breath.
+    """
+    _race = "Dragon"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._race = "Dragon"
 
 
 class Human(Creature):
+    """
+    Human creature. Likely to be the player character.
+    """
+    _race = "Human"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._race = "Human"

--- a/game_code/creatures/tests.py
+++ b/game_code/creatures/tests.py
@@ -1,44 +1,32 @@
+"""
+All tests of the creatures library.
+"""
 import unittest
 
 from game_code.creatures import Creature
-from game_code.weapons import Sword
+from game_code.stats import Stats
+from game_code.status import Status
+from game_code.weapons import Unarmed
 
 
-class TestCreatureMethods(unittest.TestCase):
+class TestCreature(unittest.TestCase):
     def test_is_alive_above_zero(self):
-        creature = Creature()
+        weapon = Unarmed(base_value=0, dice_quantity=0, dice_max=0, weight=0, value=0)
+        creature = Creature(first_name="John", second_name="Doe", stats=Stats(), status=Status(), weapon=weapon)
         creature._stats._health = 1
         self.assertEqual(1, creature.stats().health())
         self.assertEqual(True, creature.is_alive())
 
     def test_is_not_alive_at_zero(self):
-        creature = Creature()
+        weapon = Unarmed(base_value=0, dice_quantity=0, dice_max=0, weight=0, value=0)
+        creature = Creature(first_name="John", second_name="Doe", stats=Stats(), status=Status(), weapon=weapon)
         creature._stats._health = 0
         self.assertEqual(0, creature.stats().health())
         self.assertEqual(False, creature.is_alive())
 
     def test_is_not_alive_below_zero(self):
-        creature = Creature()
+        weapon = Unarmed(base_value=0, dice_quantity=0, dice_max=0, weight=0, value=0)
+        creature = Creature(first_name="John", second_name="Doe", stats=Stats(), status=Status(), weapon=weapon)
         creature._stats._health = -1
         self.assertEqual(-1, creature.stats().health())
         self.assertEqual(False, creature.is_alive())
-
-    def test_full_name_without_second_name(self):
-        creature = Creature(first_name="YeetmeisterII")
-        self.assertEqual("YeetmeisterII", creature.full_name())
-
-    def test_full_name_with_second_name(self):
-        creature = Creature(first_name="YeetmeisterII", second_name="IGOR")
-        self.assertEqual("YeetmeisterII IGOR", creature.full_name())
-
-    def test_store_weapon_without_weapon(self):
-        creature = Creature()
-        creature._store_weapon()
-        self.assertEqual([], creature._inventory)
-
-    def test_store_weapon_with_weapon(self):
-        creature = Creature()
-        weapon = Sword()
-        creature._weapon = weapon
-        creature._store_weapon()
-        self.assertEqual([weapon], creature._inventory)

--- a/game_code/factory/constants.py
+++ b/game_code/factory/constants.py
@@ -1,0 +1,60 @@
+"""
+Factory constants used in the creation of objects.
+"""
+from game_code import creatures, weapons, skills
+
+CREATURES = {
+    "goblin": creatures.Goblin,
+    "orc": creatures.Orc,
+    "earth_elemental": creatures.EarthElemental,
+    "djinn": creatures.Djinn,
+    "dragon": creatures.Dragon,
+    "human": creatures.Human,
+}
+
+DEFAULT_CREATURE_STATS = {
+    "goblin": {
+        "constitution": 10, "physicality": 5, "dexterity": 10, "gold_worth": 5, "experience_worth": 10,
+        "magic_enabled": False
+    },
+    "orc": {
+        "constitution": 15, "physicality": 13, "dexterity": 13, "gold_worth": 10, "experience_worth": 15,
+        "magic_enabled": False
+    },
+    "earth_elemental": {"constitution": 5, "physicality": 16, "dexterity": 16, "experience_worth": 30},
+    "djinn": {
+        "constitution": 10, "physicality": 5, "dexterity": 16, "social": 17, "gold_worth": 30, "experience_worth": 15
+    },
+    "dragon": {
+        "constitution": 30, "physicality": 18, "dexterity": 18, "gold_worth": 100000000, "experience_worth": 500,
+        "magic_enabled": False
+    },
+    "human": {"constitution": 10, "physicality": 10, "dexterity": 10, "social": 10, "magic_enabled": False},
+}
+
+WEAPONS = {
+    "unarmed": weapons.Unarmed,
+    "sword": weapons.Sword,
+    "dagger": weapons.Dagger,
+    "rock_fist": weapons.RockFist,
+    "fire_breath": skills.FireBreath,
+    "harsh_language": skills.HarshLanguage,
+}
+
+DEFAULT_CREATURE_WEAPONS = {
+    "goblin": "dagger",
+    "orc": "sword",
+    "earth_elemental": "rock_fist",
+    "djinn": "harsh_language",
+    "dragon": "fire_breath",
+    "human": "sword",
+}
+
+DEFAULT_WEAPON_STATS = {
+    "unarmed": {"base_value": 0, "dice_quantity": 1, "dice_max": 1, "value": 0, "weight": 0},
+    "sword": {"base_value": 0, "dice_quantity": 1, "dice_max": 6, "value": 5, "weight": 4},
+    "dagger": {"base_value": 0, "dice_quantity": 1, "dice_max": 3, "value": 2, "weight": 1},
+    "rock_fist": {"base_value": 3, "dice_quantity": 1, "dice_max": 8, "value": 0, "weight": 0},
+    "fire_breath": {"base_value": 0, "dice_quantity": 2, "dice_max": 12},
+    "harsh_language": {"base_value": 0, "dice_quantity": 1, "dice_max": 4},
+}

--- a/game_code/factory/tests.py
+++ b/game_code/factory/tests.py
@@ -1,3 +1,6 @@
+"""
+All tests for the factory library.
+"""
 import unittest
 
 from game_code.creatures import Goblin
@@ -5,119 +8,158 @@ from game_code.factory import Factory
 from game_code.weapons import Sword
 
 
-class TestCreatureCreationMethods(unittest.TestCase):
+class TestCreatureCreation(unittest.TestCase):
     def test_create_creature(self):
-        creature = Factory().create_creature("goblin")
-        self.assertEqual(type(creature), Goblin)
+        creature = Factory().create_creature(creature_class="goblin", first_name="John", second_name="Doe")
+        self.assertEqual(Goblin, type(creature))
 
-    def test_create_custom_creature(self):
-        creature = Factory().create_creature("goblin", {"physicality": 7})
-        self.assertEqual(7, creature.stats().physicality_base())
+    def test_create_creature_with_stat_values(self):
+        stat_values = {
+            "constitution": 1, "physicality": 2, "dexterity": 3, "social": 4, "experience": 5, "magic_base": 6,
+            "gold_worth": 7, "experience_worth": 8, "magic_enabled": True
+        }
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe", stat_values=stat_values
+        )
+        stats = creature.stats()
+        expected_values = (1, 2, 3, 4, 5, 6, 7, 8, True)
+        actual_values = (
+            stats.constitution(), stats.physicality_base(), stats.dexterity_base(), stats.social(), stats.experience(),
+            stats.magic_base(), stats.gold_worth(), stats.experience_worth(), stats.magic_enabled()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
     def test_default_goblin_creation(self):
-        creature = Factory().create_creature("goblin")
-        self.assertEqual(10, creature.stats().constitution())
-        self.assertEqual(5, creature.stats().physicality_base())
-        self.assertEqual(10, creature.stats().dexterity_base())
-        self.assertEqual(0, creature.stats().social())
-        self.assertEqual(5, creature.gold_worth())
-        self.assertEqual(10, creature.experience_worth())
+        creature = Factory().create_creature(creature_class="goblin", first_name="John", second_name="Doe")
+        stats = creature.stats()
+        expected_values = (10, 5, 10, 0, 0, 0, 5, 10, False)
+        actual_values = (
+            stats.constitution(), stats.physicality_base(), stats.dexterity_base(), stats.social(), stats.experience(),
+            stats.magic_base(), stats.gold_worth(), stats.experience_worth(), stats.magic_enabled()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
     def test_default_orc_creation(self):
-        creature = Factory().create_creature("orc")
-        self.assertEqual(15, creature.stats().constitution())
-        self.assertEqual(13, creature.stats().physicality_base())
-        self.assertEqual(13, creature.stats().dexterity_base())
-        self.assertEqual(0, creature.stats().social())
-        self.assertEqual(10, creature.gold_worth())
-        self.assertEqual(15, creature.experience_worth())
+        creature = Factory().create_creature(creature_class="orc", first_name="John", second_name="Doe")
+        stats = creature.stats()
+        expected_values = (15, 13, 13, 0, 0, 0, 10, 15, False)
+        actual_values = (
+            stats.constitution(), stats.physicality_base(), stats.dexterity_base(), stats.social(), stats.experience(),
+            stats.magic_base(), stats.gold_worth(), stats.experience_worth(), stats.magic_enabled()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
     def test_default_earth_elemental_creation(self):
-        creature = Factory().create_creature("earth_elemental")
-        self.assertEqual(5, creature.stats().constitution())
-        self.assertEqual(16, creature.stats().physicality_base())
-        self.assertEqual(16, creature.stats().dexterity_base())
-        self.assertEqual(0, creature.stats().social())
-        self.assertEqual(0, creature.gold_worth())
-        self.assertEqual(30, creature.experience_worth())
+        creature = Factory().create_creature(creature_class="earth_elemental", first_name="John", second_name="Doe")
+        stats = creature.stats()
+        expected_values = (5, 16, 16, 0, 0, 0, 0, 30, True)
+        actual_values = (
+            stats.constitution(), stats.physicality_base(), stats.dexterity_base(), stats.social(), stats.experience(),
+            stats.magic_base(), stats.gold_worth(), stats.experience_worth(), stats.magic_enabled()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
     def test_default_djinn_creation(self):
-        creature = Factory().create_creature("djinn")
-        self.assertEqual(10, creature.stats().constitution())
-        self.assertEqual(5, creature.stats().physicality_base())
-        self.assertEqual(16, creature.stats().dexterity_base())
-        self.assertEqual(17, creature.stats().social())
-        self.assertEqual(30, creature.gold_worth())
-        self.assertEqual(15, creature.experience_worth())
+        creature = Factory().create_creature(creature_class="djinn", first_name="John", second_name="Doe")
+        stats = creature.stats()
+        expected_values = (10, 5, 16, 17, 0, 0, 30, 15, True)
+        actual_values = (
+            stats.constitution(), stats.physicality_base(), stats.dexterity_base(), stats.social(), stats.experience(),
+            stats.magic_base(), stats.gold_worth(), stats.experience_worth(), stats.magic_enabled()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
     def test_default_dragon_creation(self):
-        creature = Factory().create_creature("dragon")
-        self.assertEqual(30, creature.stats().constitution())
-        self.assertEqual(18, creature.stats().physicality_base())
-        self.assertEqual(18, creature.stats().dexterity_base())
-        self.assertEqual(0, creature.stats().social())
-        self.assertEqual(100000000, creature.gold_worth())
-        self.assertEqual(500, creature.experience_worth())
+        creature = Factory().create_creature(creature_class="dragon", first_name="John", second_name="Doe")
+        stats = creature.stats()
+        expected_values = (30, 18, 18, 0, 0, 0, 100000000, 500, False)
+        actual_values = (
+            stats.constitution(), stats.physicality_base(), stats.dexterity_base(), stats.social(), stats.experience(),
+            stats.magic_base(), stats.gold_worth(), stats.experience_worth(), stats.magic_enabled()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
     def test_default_human_creation(self):
-        creature = Factory().create_creature("human")
-        self.assertEqual(10, creature.stats().constitution())
-        self.assertEqual(10, creature.stats().physicality_base())
-        self.assertEqual(10, creature.stats().dexterity_base())
-        self.assertEqual(10, creature.stats().social())
-        self.assertEqual(0, creature.gold_worth())
-        self.assertEqual(0, creature.experience_worth())
+        creature = Factory().create_creature(creature_class="human", first_name="John", second_name="Doe")
+        stats = creature.stats()
+        expected_values = (10, 10, 10, 10, 0, 0, 0, 0, False)
+        actual_values = (
+            stats.constitution(), stats.physicality_base(), stats.dexterity_base(), stats.social(), stats.experience(),
+            stats.magic_base(), stats.gold_worth(), stats.experience_worth(), stats.magic_enabled()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
 
-class TestWeaponCreationMethods(unittest.TestCase):
-    def test_weapon_creation(self):
+class TestWeaponCreation(unittest.TestCase):
+    def test_create_weapon(self):
         weapon = Factory().create_weapon("sword")
         self.assertEqual(Sword, type(weapon))
 
-    def test_custom_weapon_stat(self):
-        weapon = Factory().create_weapon("sword", {"base_value": 7})
-        self.assertEqual(7, weapon.base_value())
+    def test_create_weapon_with_stat_values(self):
+        stat_values = {"base_value": 1, "dice_quantity": 2, "dice_max": 3, "value": 4, "weight": 5}
+        weapon = Factory().create_weapon(weapon_class="sword", stat_values=stat_values)
+        expected_values = (1, 2, 3, 4, 5, "Sword")
+        actual_values = (
+            weapon.base_value(), weapon.dice_quantity(), weapon.dice_max(), weapon.value(), weapon.weight(),
+            weapon.name()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
-    def test_default_unarmed_creation(self):
-        weapon = Factory().create_weapon("unarmed")
-        self.assertEqual("Fist", weapon.name())
-        self.assertEqual(0, weapon.base_value())
-        self.assertEqual(1, weapon.dice_quantity())
-        self.assertEqual(1, weapon.dice_max())
-
-    def test_default_sword_creation(self):
-        weapon = Factory().create_weapon("sword")
+    def test_create_weapon_without_name(self):
+        weapon = Factory().create_weapon(weapon_class="sword")
         self.assertEqual("Sword", weapon.name())
-        self.assertEqual(0, weapon.base_value())
-        self.assertEqual(1, weapon.dice_quantity())
-        self.assertEqual(6, weapon.dice_max())
 
-    def test_default_dagger_creation(self):
+    def test_create_weapon_with_name(self):
+        weapon = Factory().create_weapon(weapon_class="sword", name="John Doe")
+        self.assertEqual("John Doe (Sword)", weapon.name())
+
+    def test_create_weapon_default_unarmed(self):
+        weapon = Factory().create_weapon("unarmed")
+        expected_values = (0, 1, 1, 0, 0, "Fist")
+        actual_values = (
+            weapon.base_value(), weapon.dice_quantity(), weapon.dice_max(), weapon.value(), weapon.weight(),
+            weapon.name()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
+
+    def test_create_weapon_default_sword(self):
+        weapon = Factory().create_weapon("sword")
+        expected_values = (0, 1, 6, 5, 4, "Sword")
+        actual_values = (
+            weapon.base_value(), weapon.dice_quantity(), weapon.dice_max(), weapon.value(), weapon.weight(),
+            weapon.name()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
+
+    def test_create_weapon_default_dagger(self):
         weapon = Factory().create_weapon("dagger")
-        self.assertEqual("Dagger", weapon.name())
-        self.assertEqual(0, weapon.base_value())
-        self.assertEqual(1, weapon.dice_quantity())
-        self.assertEqual(3, weapon.dice_max())
+        expected_values = (0, 1, 3, 2, 1, "Dagger")
+        actual_values = (
+            weapon.base_value(), weapon.dice_quantity(), weapon.dice_max(), weapon.value(), weapon.weight(),
+            weapon.name()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
-    def test_default_rock_fist_creation(self):
+    def test_create_weapon_default_rock_fist(self):
         weapon = Factory().create_weapon("rock_fist")
-        self.assertEqual("Rock Fist", weapon.name())
-        self.assertEqual(3, weapon.base_value())
-        self.assertEqual(1, weapon.dice_quantity())
-        self.assertEqual(8, weapon.dice_max())
+        expected_values = (3, 1, 8, 0, 0, "Rock Fist")
+        actual_values = (
+            weapon.base_value(), weapon.dice_quantity(), weapon.dice_max(), weapon.value(), weapon.weight(),
+            weapon.name()
+        )
+        self.assertTupleEqual(expected_values, actual_values)
 
 
-class TestSkillCreationMethods(unittest.TestCase):
+class TestSkillCreation(unittest.TestCase):
     # TODO: Refactor create_weapon to create_skill when the necessary modifications in the game_code are completed.
-    def test_default_fire_breath_creation(self):
+    def test_create_weapon_default_fire_breath(self):
         skill = Factory().create_weapon("fire_breath")
-        self.assertEqual(0, skill.base_value())
-        self.assertEqual(2, skill.dice_quantity())
-        self.assertEqual(12, skill.dice_max())
+        expected_values = (0, 2, 12, "Fire Breath")
+        actual_values = (skill.base_value(), skill.dice_quantity(), skill.dice_max(), skill.name())
+        self.assertTupleEqual(expected_values, actual_values)
 
-    def test_default_harsh_language_creation(self):
+    def test_create_weapon_default_harsh_language(self):
         skill = Factory().create_weapon("harsh_language")
-        self.assertEqual("Harsh Language", skill.name())
-        self.assertEqual(0, skill.base_value())
-        self.assertEqual(1, skill.dice_quantity())
-        self.assertEqual(4, skill.dice_max())
+        expected_values = (0, 1, 4, "Harsh Language")
+        actual_values = (skill.base_value(), skill.dice_quantity(), skill.dice_max(), skill.name())
+        self.assertTupleEqual(expected_values, actual_values)

--- a/game_code/items/__init__.py
+++ b/game_code/items/__init__.py
@@ -1,20 +1,37 @@
-from game_code.actions import NullAction
+"""
+Library of all non-living physical entities excluding weapons.
+"""
+from typing import Union
+
+from game_code.creatures import Creature
 
 
 class Item:
-    def __init__(self, value: int = 0, weight: int = 0):
+    """
+    Physical entities that are not living like Creatures.
+    """
+
+    def __init__(self, name: str, remaining_uses: Union[int, float], value: int, weight: int):
+        self._name = name
+        self._remaining_uses = remaining_uses
         self._value = value
         self._weight = weight
 
+    def name(self) -> str:
+        """
+        :return: Name of the Item.
+        """
+        return self._name
+
     def value(self) -> int:
         """
-        :return: Worth of the item in gold.
+        :return: Value of the item in gold.
         """
         return self._value
 
     def weight(self) -> int:
         """
-        :return: Quantity of inventory weight allowance taken up by the item.
+        :return: Mass of the Item in arbitrary units.
         """
         return self._weight
 
@@ -22,37 +39,37 @@ class Item:
         """
         :return: If the consumable can be used.
         """
-        return True
-
-
-class Consumable(Item):
-    """
-    An item that has a limit on the amount it can be used.
-    """
-
-    def __init__(self, remaining_uses: int = 1, **kwargs):
-        super().__init__(**kwargs)
-        self._remaining_uses = remaining_uses
-
-    def is_usable(self) -> bool:
-        """
-        :return: If the consumable can be used.
-        """
         return 0 < self._remaining_uses
 
-    def remaining_uses(self) -> int:
+    def remaining_uses(self) -> Union[int, float]:
         """
-        :return: How many times the item can be used.
+        :return: How many more times the item can be used.
         """
         return self._remaining_uses
 
-    def use(self, executor: "Creature", target: "Creature") -> NullAction:
-        # TODO: Add method to allow consumable to delete itself from the executor's inventory.
+    def use(self, executor: Creature, target: Creature):
         """
         Create action to perform when used. Delete the consumable once it runs out of uses.
         :param executor: User of the item.
         :param target: Target of the item's action.
         :return: Action to perform.
         """
-        self._remaining_uses -= 1
-        return NullAction(executor=executor, target=target, tool_used=self)
+        pass
+
+
+class ConsumableItem(Item):
+    """
+    Item with a limited quantity of uses.
+    """
+
+    def __init__(self, remaining_uses: int, **kwargs):
+        super().__init__(remaining_uses=remaining_uses, **kwargs)
+
+
+class NonConsumableItem(Item):
+    """
+    Item with an unlimited quantity of uses.
+    """
+
+    def __init__(self, name: str, value: int, weight: int):
+        super().__init__(name=name, value=value, weight=weight, remaining_uses=float("inf"))

--- a/game_code/items/healing_items.py
+++ b/game_code/items/healing_items.py
@@ -1,15 +1,19 @@
+"""
+Types of healing potions that can be used.
+"""
 from game_code.actions import HealingAction
-from game_code.items import Consumable
+from game_code.creatures import Creature
+from game_code.items import ConsumableItem
 
 
-class HealingPotion(Consumable):
+class HealingPotion(ConsumableItem):
     """
-    Base class for potions that heal creatures.
+    Base healing potion class.
     """
+    _healing_quantity = None
 
-    def __init__(self, healing_quantity, **kwargs):
-        super().__init__(**kwargs)
-        self._healing_quantity = healing_quantity
+    def __init__(self, value: int):
+        super().__init__(name=self._name, value=value, remaining_uses=1, weight=1)
 
     def healing_quantity(self) -> int:
         """
@@ -17,30 +21,45 @@ class HealingPotion(Consumable):
         """
         return self._healing_quantity
 
-    def use(self, executor: "Creature", target: "Creature") -> HealingAction:
+    def use(self, executor: Creature, target: Creature) -> HealingAction:
         """
-        Create action to perform when used. Delete the potion once it runs out of uses.
-        :param executor: User of the item.
-        :param target: Target of the item's action.
-        :return: Healing action.
+        Attempt to heal the target creature.
+        :param executor: Creature using the potion.
+        :param target: Creature being healed by potion.
+        :return: HealingAction instance.
         """
         self._remaining_uses -= 1
         return HealingAction(executor=executor, target=target, healing_quantity=self._healing_quantity, tool_used=self)
 
 
 class LesserHealingPotion(HealingPotion):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._healing_quantity = 10
+    """
+    Low-tier healing potion.
+    """
+    _healing_quantity = 10
+    _name = "Lesser Healing Potion"
+
+    def __init__(self):
+        super().__init__(value=7)
 
 
 class IntermediateHealingPotion(HealingPotion):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._healing_quantity = 20
+    """
+    Mid-tier healing potion.
+    """
+    _healing_quantity = 20
+    _name = "Intermediate Healing Potion"
+
+    def __init__(self):
+        super().__init__(value=16)
 
 
 class GreaterHealingPotion(HealingPotion):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._healing_quantity = 30
+    """
+    High-tier healing potion.
+    """
+    _healing_quantity = 30
+    _name = "Greater Healing Potion"
+
+    def __init__(self):
+        super().__init__(value=30)

--- a/game_code/items/tests.py
+++ b/game_code/items/tests.py
@@ -1,59 +1,57 @@
+"""
+All tests for the items library.
+"""
 import unittest
 
-from game_code.actions import NullAction, HealingAction
-from game_code.creatures import Creature
-from game_code.items import Consumable
-from game_code.items.healing_items import HealingPotion
+from game_code.factory import Factory
+from game_code.items import ConsumableItem
+from game_code.items.healing_items import LesserHealingPotion, IntermediateHealingPotion, \
+    GreaterHealingPotion
 
 
-class TestItemMethods(unittest.TestCase):
-    pass
-
-
-class TestConsumableMethods(unittest.TestCase):
-    def test_is_usable(self):
-        consumable = Consumable(remaining_uses=1)
+class TestItem(unittest.TestCase):
+    def test_is_usable_valid(self):
+        consumable = ConsumableItem(remaining_uses=10, name="test", value=0, weight=0)
         self.assertEqual(True, consumable.is_usable())
 
-    def test_not_usable(self):
-        consumable = Consumable(remaining_uses=0)
+    def test_is_usable_borderline_valid(self):
+        consumable = ConsumableItem(remaining_uses=1, name="test", value=0, weight=0)
+        self.assertEqual(True, consumable.is_usable())
+
+    def test_is_usable_borderline_invalid(self):
+        consumable = ConsumableItem(remaining_uses=0, name="test", value=0, weight=0)
         self.assertEqual(False, consumable.is_usable())
 
-    def test_use_action_type(self):
-        consumable = Consumable()
-        action = consumable.use(Creature(), Creature())
-        self.assertEqual(NullAction, type(action))
+    def test_is_usable_invalid(self):
+        consumable = ConsumableItem(remaining_uses=-1, name="test", value=0, weight=0)
+        self.assertEqual(False, consumable.is_usable())
 
 
-class TestHealthPotionMethods(unittest.TestCase):
-    def test_is_usable(self):
-        healing_potion = HealingPotion(remaining_uses=1, healing_quantity=0)
-        self.assertEqual(True, healing_potion.is_usable())
+class TestHealthPotion(unittest.TestCase):
+    def test_use_remaining_uses_reduction(self):
+        healing_potion = LesserHealingPotion()
+        executor = Factory().create_creature(creature_class="goblin", first_name="John", second_name="Doe")
+        target = Factory().create_creature(creature_class="goblin", first_name="Charles", second_name="Brown")
+        healing_potion.use(executor=executor, target=target)
+        self.assertEqual(0, healing_potion.remaining_uses())
 
-    def test_not_usable(self):
-        healing_potion = HealingPotion(remaining_uses=0, healing_quantity=0)
-        self.assertEqual(False, healing_potion.is_usable())
+    def test_use_lesser_healing_potion_healing_quantity(self):
+        healing_potion = LesserHealingPotion()
+        executor = Factory().create_creature(creature_class="goblin", first_name="John", second_name="Doe")
+        target = Factory().create_creature(creature_class="goblin", first_name="Charles", second_name="Brown")
+        action = healing_potion.use(executor=executor, target=target)
+        self.assertEqual(10, action.healing_quantity())
 
-    def test_use_action_type(self):
-        healing_potion = HealingPotion(healing_quantity=0)
-        action = healing_potion.use(Creature(), Creature())
-        self.assertEqual(HealingAction, type(action))
+    def test_use_intermediate_healing_potion_healing_quantity(self):
+        healing_potion = IntermediateHealingPotion()
+        executor = Factory().create_creature(creature_class="goblin", first_name="John", second_name="Doe")
+        target = Factory().create_creature(creature_class="goblin", first_name="Charles", second_name="Brown")
+        action = healing_potion.use(executor=executor, target=target)
+        self.assertEqual(20, action.healing_quantity())
 
-    def test_use_action_healing_quantity(self):
-        healing_potion = HealingPotion(healing_quantity=7)
-        action = healing_potion.use(Creature(), Creature())
-        self.assertEqual(7, action.healing_quantity())
-
-    def test_use_action_executor(self):
-        healing_potion = HealingPotion(healing_quantity=0)
-        creature1 = Creature()
-        creature2 = Creature()
-        action = healing_potion.use(executor=creature1, target=creature2)
-        self.assertEqual(creature1, action.executor())
-
-    def test_use_action_target(self):
-        healing_potion = HealingPotion(healing_quantity=0)
-        creature1 = Creature()
-        creature2 = Creature()
-        action = healing_potion.use(executor=creature1, target=creature2)
-        self.assertEqual(creature2, action.target())
+    def test_use_greater_healing_potion_healing_quantity(self):
+        healing_potion = GreaterHealingPotion()
+        executor = Factory().create_creature(creature_class="goblin", first_name="John", second_name="Doe")
+        target = Factory().create_creature(creature_class="goblin", first_name="Charles", second_name="Brown")
+        action = healing_potion.use(executor=executor, target=target)
+        self.assertEqual(30, action.healing_quantity())

--- a/game_code/response/__init__.py
+++ b/game_code/response/__init__.py
@@ -1,16 +1,34 @@
-from typing import List, Union, Tuple
+""":str
+Response classes used to inform the player the consequence of actions that creatures have taken.
+"""
+from typing import Tuple, Union
 
 
 class Response:
     """
-    Sums up the result of an action.
+    Returned after calling an action.
     """
 
-    def __init__(self, executor_name: str = None, target_name: str = None):
-        self._executor = executor_name
-        self._target = target_name
+    def __init__(
+            self, executor_name: str = None, target_name: str = None, tool_name: str = None, damage: int = None,
+            outcome: str = None):
+        self._executor_name = executor_name
+        self._target_name = target_name
+        self._tool_name = tool_name
+        self._damage = damage
+        self._outcome = outcome
 
-    def _convert_to_possessive_noun(self, proper_noun: str) -> str:
+    def __call__(self):
+        return self._result()
+
+    def _result(self) -> None:
+        """
+        Convert the information of an action's outcome into player readable strings detailing what happened and why.
+        """
+        pass
+
+    # TODO: Move this method to a dedicated string editing class.
+    def _to_possessive_noun(self, proper_noun: str) -> str:
         """
         Takes a name and turns it into the possessive form e.g. John Doe -> John Doe's.
         :param proper_noun: The name to convert.
@@ -18,17 +36,19 @@ class Response:
         """
         if not proper_noun:
             raise ValueError("Cannot be an empty string.")
-        return f"{proper_noun}'" if proper_noun[-1] == "s" else f"{proper_noun}'s"
-
-    def result(self) -> List[str]:
-        return []
+        return f"{proper_noun}'" + ("s" * (proper_noun[-1] != "s"))
 
 
 class NullResponse(Response):
     """
-    Response object used when an action has no outcome.
+    Response used when the action has no outcome or does not need to be displayed.
     """
-    pass
+
+    def _result(self) -> tuple:
+        """
+        :return: Empty tuple.
+        """
+        return tuple()
 
 
 class AttackResponse(Response):
@@ -37,39 +57,31 @@ class AttackResponse(Response):
     """
 
     def __init__(self, executor_name: str, target_name: str, tool_name: str, damage: Union[str, int], outcome: str):
-        super().__init__(executor_name=executor_name, target_name=target_name)
-        self._result = self._create_result(executor_name=executor_name, target_name=target_name,
-                                           tool_name=tool_name, damage=damage, outcome=outcome)
+        super().__init__(
+            executor_name=executor_name, target_name=target_name, tool_name=tool_name, damage=damage, outcome=outcome
+        )
 
-    def __call__(self, *args, **kwargs):
-        return self._result
+    def _result(self) -> Tuple[str, str, str]:
+        """
+        Create tuple containing three strings.
+        In order they are they describe:
+        1. Who attacked and with what tool.
+        2. Whether the attack hit or missed.
+        3. How much damage was dealt.
+        :return: Tuple of strings detailing the outcome of the attack.
+        """
+        attempted_action = f"{self._executor_name} attacks {self._target_name} with {self._tool_name}."
+        damage_dealt = f"{self._target_name} takes {self._damage} damage."
 
-    def result(self) -> Tuple[str, str, str]:
-        """
-        :return: Tuple containing strings describing the result of an action.
-        """
-        return self._result
+        executor_name_possessive = self._to_possessive_noun(self._executor_name)
+        target_name_possessive = self._to_possessive_noun(self._target_name)
 
-    def _create_result(self, executor_name: str, target_name: str, tool_name: str, damage: int,
-                       outcome: str) -> Tuple[str, str, str]:
-        """
-        Create a tuple containing strings that describe the result of an action.
-        :param executor_name: Name of object performing attack.
-        :param target_name: Name of object attack was aimed at.
-        :param tool_name: Name of item (may not be physical) that was used in performing the attack.
-        :param damage: Damage dealt from the attack.
-        :param outcome: Whether the attack was a critical hit, hit, miss or a critical miss.
-        :return: Tuple of the result for user reading.
-        """
-        executor_name_possessive = self._convert_to_possessive_noun(executor_name)
-        target_name_possessive = self._convert_to_possessive_noun(target_name)
-        outcomes = {
+        potential_explanations = {
             "critical_hit": f"Critical Hit! {executor_name_possessive} attack bypasses {target_name_possessive} "
                             f"defences.",
-            "hit": f"{executor_name_possessive} attack lands on {target_name}.",
-            "miss": f"{executor_name_possessive} attack misses {target_name}.",
+            "hit": f"{executor_name_possessive} attack lands on {self._target_name}.",
+            "miss": f"{executor_name_possessive} attack misses {self._target_name}.",
             "critical_miss": f"Critical miss. {executor_name_possessive} attack fails expeditiously.",
         }
-
-        return (f"{executor_name} attacks {target_name} with {tool_name}.", outcomes[outcome],
-                f"{target_name} takes {damage} damage.")
+        explanation = potential_explanations[self._outcome]
+        return attempted_action, explanation, damage_dealt

--- a/game_code/response/tests.py
+++ b/game_code/response/tests.py
@@ -1,17 +1,20 @@
+"""
+All tests for the response library.
+"""
 import unittest
 
 from game_code.response import Response
 
 
-class TestResponseMethods(unittest.TestCase):
+class TestResponse(unittest.TestCase):
     def test_possessive_noun_conversion_not_ending_in_s(self):
-        possessive = Response()._convert_to_possessive_noun("John Doe")
+        possessive = Response()._to_possessive_noun("John Doe")
         self.assertEqual("John Doe's", possessive)
 
     def test_possessive_noun_conversion_ending_in_s(self):
-        possessive = Response()._convert_to_possessive_noun("John Does")
+        possessive = Response()._to_possessive_noun("John Does")
         self.assertEqual("John Does'", possessive)
 
     def test_possessive_noun_conversion_blank_string(self):
         with self.assertRaises(ValueError) as cm:
-            Response()._convert_to_possessive_noun("")
+            Response()._to_possessive_noun("")

--- a/game_code/skills/__init__.py
+++ b/game_code/skills/__init__.py
@@ -1,14 +1,23 @@
+"""
+Library containing the skills that can be learnt by Creatures.
+"""
 import random
 
 from game_code.actions import AttackAction, NullAction
+from game_code.creatures import Creature
 
 
 class Skill:
-    def __init__(self, dice_quantity: int = 0, dice_max: int = 0, base_value: int = 0, skill_name: str = "skill"):
+    """
+    Base skill class.
+    """
+
+    _name = None
+
+    def __init__(self, dice_quantity: int, dice_max: int, base_value: int):
         self._dice_quantity = dice_quantity
         self._dice_max = dice_max
         self._base_value = base_value
-        self._name = skill_name
 
     def name(self) -> str:
         """
@@ -34,21 +43,24 @@ class Skill:
         """
         return self._base_value
 
-    def use(self, executor: "Creature", target: "Creature") -> NullAction:
+    def use(self, executor: Creature, target: Creature) -> NullAction:
         """
         Create attempted action upon the target when skill is used.
         :param executor: Performer of the skill.
         :param target: Target of the skill.
-        :return: Action to perform.
         """
-        return NullAction(executor=executor, target=target, tool_used=self)
+        pass
 
 
 class OffensiveSkill(Skill):
+    """
+    Base class for skills primarily used to deal damage.
+    """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def use(self, executor: "Creature", target: "Creature") -> AttackAction:
+    def use(self, executor: Creature, target: Creature) -> AttackAction:
         """
         Calculate damage of skill based on quantity of dice, max value of the dice and the base value.
         :param executor: Performer of the skill.
@@ -58,15 +70,20 @@ class OffensiveSkill(Skill):
         hit_index = random.randint(1, 20)
         rolled_damage = sum(random.randint(1, self._dice_max) for roll in range(self._dice_quantity))
         damage = rolled_damage + self._base_value
-        return AttackAction(damage=damage, hit_index=hit_index)
+        return AttackAction(executor=executor, target=target, damage=damage, hit_index=hit_index, tool_used=self)
 
 
 class HarshLanguage(OffensiveSkill):
+    """
+    Racial skill for Djinns. It uses the orthodox attack logic except the executors charisma is added to the damage
+    instead of the base damage.
+    """
+    _name = "Harsh Language"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._name = "Harsh Language"
 
-    def use(self, executor: "Creature", target: "Creature") -> AttackAction:
+    def use(self, executor: Creature, target: Creature) -> AttackAction:
         """
         Calculate damage of skill based on quantity of dice, max value of the dice and the executor's charisma.
         :param executor: Performer of the skill.
@@ -80,6 +97,10 @@ class HarshLanguage(OffensiveSkill):
 
 
 class FireBreath(OffensiveSkill):
+    """
+    Racial skill for Dragons.
+    """
+    _name = "Fire Breath"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._name = "Fire Breath"

--- a/game_code/skills/tests.py
+++ b/game_code/skills/tests.py
@@ -1,33 +1,18 @@
+"""
+All tests for the skills library.
+"""
 import unittest
 
-from game_code.actions import NullAction
-from game_code.creatures import Creature
-from game_code.skills import Skill, HarshLanguage
+from game_code.factory import Factory
+from game_code.skills import HarshLanguage
 
 
-class TestSkillMethods(unittest.TestCase):
-    def test_use_action(self):
-        skill = Skill()
-        action = skill.use(Creature(), Creature())
-        self.assertEqual(NullAction, type(action))
-
-
-class TestHarshLanguageMethods(unittest.TestCase):
+class TestHarshLanguage(unittest.TestCase):
     def test_use_action_base_damage_using_social(self):
-        harsh_language_skill = HarshLanguage(base_value=10, dice_quantity=0, dice_max=0)
-        action = harsh_language_skill.use(Creature(social=5), Creature())
+        harsh_language_skill = HarshLanguage(base_value=0, dice_quantity=0, dice_max=0)
+        creature1 = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe", stat_values={"social": 5}
+        )
+        creature2 = Factory().create_creature(creature_class="goblin", first_name="Charles", second_name="Brown")
+        action = harsh_language_skill.use(creature1, creature2)
         self.assertEqual(5, action.damage())
-
-    def test_use_action_executor(self):
-        harsh_language_skill = HarshLanguage()
-        creature1 = Creature()
-        creature2 = Creature()
-        action = harsh_language_skill.use(executor=creature1, target=creature2)
-        self.assertEqual(creature1, action.executor())
-
-    def test_use_action_target(self):
-        harsh_language_skill = HarshLanguage()
-        creature1 = Creature()
-        creature2 = Creature()
-        action = harsh_language_skill.use(executor=creature1, target=creature2)
-        self.assertEqual(creature2, action.target())

--- a/game_code/spells/__init__.py
+++ b/game_code/spells/__init__.py
@@ -1,13 +1,21 @@
+"""
+Library containing the spells that Creatures can learn to cast.
+"""
 import random
 
-from game_code.actions import AttackAction, HealingAction, NullAction
+from game_code.actions import AttackAction, HealingAction
+from game_code.creatures import Creature
 
 
 class Spell:
-    def __init__(self, cost: int = 0):
+    """
+    Base spell class.
+    """
+
+    def __init__(self, cost: int):
         self._mana_cost = cost
 
-    def is_usable(self, caster: "Creature") -> bool:
+    def is_usable(self, caster: Creature) -> bool:
         """
         Check whether spell can be cast.
         :param caster: Creature being checked.
@@ -15,22 +23,26 @@ class Spell:
         """
         return caster.stats().magic_enabled() and (self._mana_cost <= caster.stats().mana())
 
-    def use(self, executor: "Creature", target: "Creature") -> NullAction:
+    def use(self, executor: Creature, target: Creature) -> None:
         """
         Create attempted action when spell is used.
         :param executor: Performer of the spell.
         :param target: Target of the spell.
         :return: Action to spell.
         """
-        return NullAction(executor=executor, target=target, tool_used=self)
+        pass
 
 
 class HealingSpell(Spell):
+    """
+    Base class for spells that heal Creatures.
+    """
+
     def __init__(self, healing_quantity: int, **kwargs):
         super().__init__(**kwargs)
         self._healing_quantity = healing_quantity
 
-    def use(self, executor: "Creature", target: "Creature") -> HealingAction:
+    def use(self, executor: Creature, target: Creature) -> HealingAction:
         """
         Cast spell that attempts to heal target.
         :param executor: Creature casting spell.
@@ -41,11 +53,15 @@ class HealingSpell(Spell):
 
 
 class OffensiveSpell(Spell):
+    """
+    Base class for spells that deal damage.
+    """
+
     def __init__(self, damage: int, **kwargs):
         super().__init__(**kwargs)
         self._damage = damage
 
-    def use(self, executor: "Creature", target: "Creature") -> AttackAction:
+    def use(self, executor: Creature, target: Creature) -> AttackAction:
         """
         Cast spell that attempts to deal damage to target.
         :param executor: Creature casting spell.
@@ -53,4 +69,4 @@ class OffensiveSpell(Spell):
         :return: Attack action.
         """
         hit_index = random.randint(1, 20)
-        return AttackAction(damage=self._damage, hit_index=hit_index)
+        return AttackAction(executor=executor, target=target, damage=self._damage, hit_index=hit_index, tool_used=self)

--- a/game_code/spells/tests.py
+++ b/game_code/spells/tests.py
@@ -1,48 +1,73 @@
+"""
+All tests for the spells library.
+"""
 import unittest
 
-from game_code.actions import NullAction, HealingAction
-from game_code.creatures import Creature
-from game_code.spells import Spell, HealingSpell
+from game_code.factory import Factory
+from game_code.spells import Spell
 
 
-class TestSpellMethods(unittest.TestCase):
-    def test_is_usable(self):
+class TestSpell(unittest.TestCase):
+    def test_is_usable_magic_enabled_and_valid_mana(self):
         spell = Spell(cost=1)
-        spell_casting_creature = Creature(magic_enabled=True, magic_base=1000)
-        self.assertEqual(True, spell.is_usable(spell_casting_creature))
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe",
+            stat_values={"magic_enabled": True, "magic_base": 10}
+        )
+        self.assertEqual(True, spell.is_usable(creature))
 
-    def test_not_usable(self):
+    def test_is_usable_magic_enabled_and_borderline_valid_mana(self):
         spell = Spell(cost=1)
-        non_spell_casting_creature = Creature(magic_enabled=False, magic_base=0)
-        self.assertEqual(False, spell.is_usable(non_spell_casting_creature))
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe",
+            stat_values={"magic_enabled": True, "magic_base": 1}
+        )
+        self.assertEqual(True, spell.is_usable(creature))
 
-    def test_use_action_type(self):
-        spell = Spell()
-        action = spell.use(Creature(), Creature())
-        self.assertEqual(NullAction, type(action))
+    def test_is_usable_magic_enabled_and_borderline_invalid_mana(self):
+        spell = Spell(cost=1)
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe",
+            stat_values={"magic_enabled": True, "magic_base": 0}
+        )
+        self.assertEqual(False, spell.is_usable(creature))
 
+    def test_is_usable_magic_enabled_and_invalid_mana(self):
+        spell = Spell(cost=1)
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe",
+            stat_values={"magic_enabled": True, "magic_base": -10}
+        )
+        self.assertEqual(False, spell.is_usable(creature))
 
-class TestHealingSpellMethods(unittest.TestCase):
-    def test_use_action_type(self):
-        healing_spell = HealingSpell(healing_quantity=0)
-        action = healing_spell.use(Creature(), Creature())
-        self.assertEqual(HealingAction, type(action))
+    def test_is_usable_magic_not_enabled_and_valid_mana(self):
+        spell = Spell(cost=1)
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe",
+            stat_values={"magic_enabled": False, "magic_base": 10}
+        )
+        self.assertEqual(False, spell.is_usable(creature))
 
-    def test_use_action_healing_quantity(self):
-        healing_spell = HealingSpell(healing_quantity=5)
-        action = healing_spell.use(Creature(), Creature())
-        self.assertEqual(5, action.healing_quantity())
+    def test_is_usable_magic_not_enabled_and_borderline_valid_mana(self):
+        spell = Spell(cost=1)
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe",
+            stat_values={"magic_enabled": False, "magic_base": 1}
+        )
+        self.assertEqual(False, spell.is_usable(creature))
 
-    def test_use_action_executor(self):
-        healing_spell = HealingSpell(healing_quantity=0)
-        creature1 = Creature()
-        creature2 = Creature()
-        action = healing_spell.use(executor=creature1, target=creature2)
-        self.assertEqual(creature1, action.executor())
+    def test_is_usable_magic_not_enabled_and_borderline_invalid_mana(self):
+        spell = Spell(cost=1)
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe",
+            stat_values={"magic_enabled": False, "magic_base": 0}
+        )
+        self.assertEqual(False, spell.is_usable(creature))
 
-    def test_use_action_target(self):
-        healing_spell = HealingSpell(healing_quantity=0)
-        creature1 = Creature()
-        creature2 = Creature()
-        action = healing_spell.use(executor=creature1, target=creature2)
-        self.assertEqual(creature2, action.target())
+    def test_is_usable_magic_not_enabled_and_invalid_mana(self):
+        spell = Spell(cost=1)
+        creature = Factory().create_creature(
+            creature_class="goblin", first_name="John", second_name="Doe",
+            stat_values={"magic_enabled": False, "magic_base": -10}
+        )
+        self.assertEqual(False, spell.is_usable(creature))

--- a/game_code/stats/__init__.py
+++ b/game_code/stats/__init__.py
@@ -1,16 +1,16 @@
+"""
+Management of the stats that a creature has.
+"""
+
+
 class Stats:
     """
     Handles the get and set of a creatures stats.
     """
 
-    def __init__(self,
-                 constitution: int = 0,
-                 physicality: int = 0,
-                 dexterity: int = 0,
-                 social: int = 0,
-                 experience: int = 0,
-                 magic_base: int = 0,
-                 magic_enabled: bool = True):
+    def __init__(
+            self, constitution: int = 0, physicality: int = 0, dexterity: int = 0, social: int = 0, experience: int = 0,
+            magic_base: int = 0, magic_enabled: bool = True, gold_worth: int = 0, experience_worth: int = 0):
         self._constitution = self._health = constitution
         self._magic_base = self._mana = magic_base
         self._social = self._charisma = social
@@ -18,6 +18,8 @@ class Stats:
         self._dexterity_base = self._dexterity = dexterity
         self._magic_enabled = magic_enabled
         self._experience = experience
+        self._gold_worth = gold_worth
+        self._experience_worth = experience_worth
 
     def magic_enabled(self) -> bool:
         """
@@ -313,3 +315,16 @@ class Stats:
         """
         self._experience += amount
         return amount
+
+    def gold_worth(self) -> int:
+        """
+        :return: Gold reward for killing a creature (is distinct from the gold that a creature has in their inventory).
+        """
+        return self._gold_worth
+
+    def experience_worth(self) -> int:
+        """
+        :return: Experience reward for killing a creature (is distinct from the experience that a creature has
+        accumulated).
+        """
+        return self._experience_worth

--- a/game_code/stats/tests.py
+++ b/game_code/stats/tests.py
@@ -1,9 +1,12 @@
+"""
+All tests for the stats library.
+"""
 import unittest
 
 from game_code.stats import Stats
 
 
-class TestStatsMethods(unittest.TestCase):
+class TestStats(unittest.TestCase):
     def test_health_increase(self):
         stats = Stats()
         stats._constitution = 10

--- a/game_code/status/__init__.py
+++ b/game_code/status/__init__.py
@@ -1,9 +1,20 @@
+"""
+Library housing the logic of the Status class and Effect classes.
+A creature's Status instance is used to manage the state of a creature, such as whether or not it is blocking.
+The Effect classes are used to give a Status and by extension a creature status effects.
+"""
 from typing import List, Type
 
+from game_code.creatures import Creature
+from game_code.response import Response
 from game_code.status.effects import Block, Effect
 
 
 class Status:
+    """
+    Holds the status effects of a creature. Is used to obtain state information about a creature.
+    """
+
     def __init__(self):
         self._effects = []
 
@@ -27,34 +38,34 @@ class Status:
         """
         return Block in self
 
-    def add_effect(self, effect: "Effect") -> None:
+    def add_effect(self, effect: Effect) -> None:
         """
         :param effect: Effect to apply to creature.
         """
         self._effects.append(effect)
 
-    def remove_effect(self, effect: "Effect") -> None:
+    def remove_effect(self, effect: Effect) -> None:
         """
         :param effect: Effect or remove from creature
         """
         self._effects.remove(effect)
 
-    def end_turn(self, self_creature: "Creature") -> List["Response"]:
+    def end_turn(self, parent_creature: Creature) -> List[Response]:
         """
         Get Response objects that are created at the end of a turn from all effects.
-        :param self_creature: Creature the Status object is managing.
+        :param parent_creature: Creature the Status object is managing.
         :return: List of Response objects.
         """
-        return [self._end_turn_effect(effect, self_creature) for effect in self._effects]
+        return [self._end_turn_effect(effect, parent_creature) for effect in self._effects]
 
-    def _end_turn_effect(self, effect: "Effect", self_creature: "Creature") -> "Response":
+    def _end_turn_effect(self, effect: Effect, parent_creature: Creature) -> Response:
         """
         Performs the end turn method on an effect, then checks if the effect should be removed from the list of effects.
         :param effect: Effect to get response from.
-        :param self_creature: Creature the Status object is managing.
+        :param parent_creature: Creature the Status object is managing.
         :return:
         """
-        action = effect.end_turn(self_creature)
+        action = effect.end_turn(parent_creature)
         if effect.turns() < 1:
             self._effects.remove(effect)
         return action

--- a/game_code/status/effects.py
+++ b/game_code/status/effects.py
@@ -1,22 +1,47 @@
+"""
+Status effect classes.
+"""
 from game_code.actions import NullAction
+from game_code.creatures import Creature
 
 
 class Effect:
+    """
+    Base Effect class. Used to give creatures status effects.
+    """
     _name = "Effect"
 
     def __init__(self, turns=1):
         self._turns = turns
 
-    def name(self):
+    def name(self) -> str:
+        """
+        :return: Name of the effect.
+        """
         return self._name
 
-    def turns(self):
+    def turns(self) -> int:
+        """
+        :return: How many more turns the effect will last.
+        """
         return self._turns
 
-    def end_turn(self, effected_creature: "Creature") -> "Action":
-        self._turns -= 1
-        return NullAction(executor=self._name, target=effected_creature, tool_used=self)
+    def end_turn(self) -> None:
+        """
+        :return: The action that needs to take place due to the effect.
+        """
+        pass
 
 
 class Block(Effect):
+    """
+    Status effect for when a creature is currently blocking.
+    """
     _name = "Blocking"
+
+    def end_turn(self, parent_creature: Creature) -> NullAction:
+        """
+        :param parent_creature: Creature being effected by the status effect.
+        :return: NullAction instance.
+        """
+        return NullAction()

--- a/game_code/status/tests.py
+++ b/game_code/status/tests.py
@@ -1,11 +1,12 @@
+"""
+All tests for the status library.
+"""
 import unittest
 
-from game_code.actions import NullAction
-from game_code.creatures import Creature
 from game_code.status import Block, Status
 
 
-class TestStatusMethods(unittest.TestCase):
+class TestStatus(unittest.TestCase):
     def test_contains(self):
         status = Status()
         effect = Block()
@@ -27,26 +28,3 @@ class TestStatusMethods(unittest.TestCase):
         status = Status()
         status._effects = []
         self.assertFalse(status.is_blocking())
-
-    def test_end_turn_actions(self):
-        status = Status()
-        creature = Creature()
-        effect = Block()
-        status._effects = [effect]
-        responses = status.end_turn(self_creature=creature)
-        self.assertEqual([NullAction], list(map(type, responses)))
-
-    def test_end_turn_timed_out_effect(self):
-        status = Status()
-        creature = Creature()
-        status._effects = [Block()]
-        responses = status.end_turn(self_creature=creature)
-        self.assertEqual(status._effects, [])
-
-    def test_end_turn_non_timed_out_effect(self):
-        status = Status()
-        creature = Creature()
-        effect = Block(turns=2)
-        status._effects = [effect]
-        responses = status.end_turn(self_creature=creature)
-        self.assertEqual(status._effects, [effect])

--- a/game_code/weapons/__init__.py
+++ b/game_code/weapons/__init__.py
@@ -1,29 +1,37 @@
+"""
+Library of weapons that can be used by creatures.
+"""
 import random
 
 from game_code.actions import AttackAction
-from game_code.items import Item
+from game_code.creatures import Creature
+from game_code.items import NonConsumableItem
 
 
-class Weapon(Item):
+class Weapon(NonConsumableItem):
     """
     Used to perform attacks. Is a holdable item.
     """
+    _weapon_type = None
+    _name_changed = False
 
-    def __init__(self, name: str = "default weapon", base_value: int = 0, dice_quantity: int = 0, dice_max: int = 0,
-                 **kwargs):
+    def __init__(self, base_value: int, dice_quantity: int, dice_max: int, **kwargs):
         super().__init__(**kwargs)
-        self._name = name
-        self._name_changed = False if name == "default weapon" else True
         self._base_value = base_value
         self._dice_quantity = dice_quantity
         self._dice_max = dice_max
-        self._weapon_type = ''
 
     def name(self) -> str:
         """
         :return: Name of weapon. Append weapon type onto name if the name has ben changed.
         """
         return f"{self._name} ({self._weapon_type})" if self._name_changed else self._name
+
+    def has_name_changed(self) -> bool:
+        """
+        :return: Whether the weapon no longer has the default name.
+        """
+        return self._name_changed
 
     def change_name(self, new_name: str) -> str:
         """
@@ -59,7 +67,7 @@ class Weapon(Item):
         """
         return self._dice_max
 
-    def use(self, executor: "Creature", target: "Creature") -> AttackAction:
+    def use(self, executor: Creature, target: Creature) -> AttackAction:
         """
         Create attempted action upon the target when weapon is used.
         :param executor: Performer of the skill.
@@ -73,28 +81,44 @@ class Weapon(Item):
 
 
 class Unarmed(Weapon):
+    """
+    Default weapon for most creatures if no weapon is equipped.
+    """
+    _weapon_type = "Fist"
+
     def __init__(self, name: str = "Fist", **kwargs):
-        super().__init__(name, **kwargs)
-        self._name_changed = False if name == "Fist" else True
-        self._weapon_type = "Unarmed"
+        super().__init__(name=name, **kwargs)
+        self._name_changed = (self._name != "Fist")
 
 
 class Sword(Weapon):
+    """
+    Orthodox weapon.
+    """
+    _weapon_type = "Sword"
+
     def __init__(self, name: str = "Sword", **kwargs):
-        super().__init__(name, **kwargs)
-        self._name_changed = False if name == "Sword" else True
-        self._weapon_type = "Sword"
+        super().__init__(name=name, **kwargs)
+        self._name_changed = (name != "Sword")
 
 
 class Dagger(Weapon):
+    """
+    Orthodox weapon.
+    """
+    _weapon_type = "Dagger"
+
     def __init__(self, name: str = "Dagger", **kwargs):
-        super().__init__(name, **kwargs)
-        self._name_changed = False if name == "Dagger" else True
-        self._weapon_type = "Dagger"
+        super().__init__(name=name, **kwargs)
+        self._name_changed = (name != "Dagger")
 
 
 class RockFist(Weapon):
+    """
+    Default racial weapon for Earth Elementals.
+    """
+    _weapon_type = "Rock Fist"
+
     def __init__(self, name: str = "Rock Fist", **kwargs):
-        super().__init__(name, **kwargs)
-        self._name_changed = False if name == "Rock Fist" else True
-        self._weapon_type = "Rock Fist"
+        super().__init__(name=name, **kwargs)
+        self._name_changed = (name != "Rock Fist")

--- a/game_code/weapons/tests.py
+++ b/game_code/weapons/tests.py
@@ -1,32 +1,25 @@
+"""
+All tests for the weapons library.
+"""
 import unittest
 
-from game_code.actions import AttackAction
-from game_code.creatures import Creature
-from game_code.weapons import Weapon
+from game_code.weapons import Sword
 
 
-class TestWeaponMethods(unittest.TestCase):
-    def test_weapon_rename(self):
-        weapon = Weapon()
-        self.assertEqual("default weapon", weapon.name())
-        weapon.change_name("modified name")
-        self.assertEqual("modified name ()", weapon.name())
+class TestWeapon(unittest.TestCase):
+    def test_weapon_has_name_changed_false(self):
+        sword = Sword(base_value=0, dice_max=0, dice_quantity=0, value=0, weight=0)
+        self.assertEqual("Sword", sword.name())
+        self.assertEqual(False, sword.has_name_changed())
 
-    def test_use_action_type(self):
-        weapon = Weapon()
-        action = weapon.use(Creature(), Creature())
-        self.assertEqual(AttackAction, type(action))
+    def test_weapon_renamed_at_instantiation(self):
+        sword = Sword(name="test name", base_value=0, dice_max=0, dice_quantity=0, value=0, weight=0)
+        self.assertEqual("test name (Sword)", sword.name())
+        self.assertEqual(True, sword.has_name_changed())
 
-    def test_use_action_executor(self):
-        weapon = Weapon()
-        creature1 = Creature()
-        creature2 = Creature()
-        action = weapon.use(creature1, creature2)
-        self.assertEqual(creature1, action.executor())
-
-    def test_use_action_target(self):
-        weapon = Weapon()
-        creature1 = Creature()
-        creature2 = Creature()
-        action = weapon.use(creature1, creature2)
-        self.assertEqual(creature2, action.target())
+    def test_weapon_renamed_after_instantiation(self):
+        sword = Sword(base_value=0, dice_max=0, dice_quantity=0, value=0, weight=0)
+        self.assertEqual("Sword", sword.name())
+        sword.change_name("test name")
+        self.assertEqual("test name (Sword)", sword.name())
+        self.assertEqual(True, sword.has_name_changed())


### PR DESCRIPTION
The classes were too closely coupled leading to circular imports and
spaghetti code. The coupling has been loosened and in the process,
large changes to improve quality of the code have been made.

Additions:
-Add docstrings for classes and files.
-Add missing docstrings for non-placeholder methods.
-Add _name class attribute to Item class.
-Move Factory constants to a dedicated python file to improve
 readability.
-Add NonConsumable class.
-Add attributes of Response subclasses to Response. Now subclasses only
 use a subset of Response's attributes and overwrite the abstract
 "_result" method.

Changes:
-Improve quality of docstrings.
-Change Skill instance attribute _name to a class attribute.
-Change Creature instance attribute _race to a class attribute.
-Change Weapon instance attribute _weapon_type to a class attribute.
-Change HealingPotion instance attribute _healing_quantity to class
 attribute.
-Refactor Weapon class to be subclass NonConsumableItem.
-Refactor Factory class to improve usability.
-Refactor tests to account for changes.
-Refactor Creature class to have stats instance passed as a parameter,
 rather than instantiating the Stats instance within the Creature
 __init__ to reduce how closely coupled the classes are.
-Rename Consumable to ConsumableItem for readability.
-Replace "Creature" type hint with Creature if it does not cause a
 circular import to improve IDE support.
-Move _remaining_uses attribute from ConsumableItem class to base Item
 class. NonConsumableItem class has _remaining_uses set to infinite.
-Move gold_worth, experience_worth, and magic_enabled parameters from
 Creature class to Stats class because it is more suitable to store it
 there.
-Move Consumable methods to superclass to reduce repetition.

Removals:
-Remove Skill default parameters, parameter must now be passed to remove
 ambiguity.
-Remove Creature default parameters, parameter must now be passed to
 remove ambiguity.
-Remove Item default parameters, parameter must now be passed to remove
 ambiguity.
-Remove Creature "basic_attack" method. It is unnecessary because one
 can use the "use()" method the creature's weapon directly.